### PR TITLE
AutoComplete: use the same text offset for suggestion items

### DIFF
--- a/src/controls/AutoComplete.js
+++ b/src/controls/AutoComplete.js
@@ -41,8 +41,8 @@ AutoComplete.prototype.createSuggestionItem = function (text, width, height) {
         container.addChild(background);
     }
 
-    itemText.x = 0;
-    itemText.y = 5;
+    itemText.x = this.textOffset.x;
+    itemText.y = this.textOffset.y;
 
     container.hitArea = new PIXI.Rectangle(0, 0, width, height);
 


### PR DESCRIPTION
this textOffset property is set in InputControl (base class) for main text, using it allows popup items to be better aligned